### PR TITLE
RDKB-60023: Failed to Set Default country code as `IE` for UK patner …

### DIFF
--- a/source/db/wifi_db_apis.c
+++ b/source/db/wifi_db_apis.c
@@ -7449,9 +7449,9 @@ void init_wifidb_data()
             if (country_code[0] != 0) {
                 char radio_country_code[COUNTRY_CODE_LEN] = {0};
                 wifi_countrycode_type_t r_country_code;
-                strncpy(radio_country_code, country_code, strlen(country_code) - 1);
+                strncpy(radio_country_code, country_code, sizeof(radio_country_code) - 1);
                 if (country_code_conversion(&r_country_code, radio_country_code, COUNTRY_CODE_LEN, STRING_TO_ENUM) < 0) {
-                        wifi_util_dbg_print(WIFI_DB,"%s:%d: unable to convert country string\n", __func__, __LINE__);
+                        wifi_util_dbg_print(WIFI_DB,"%s:%d: unable to convert country string, country_code = %s\n", __func__, __LINE__,radio_country_code);
                 } else {
                     if (l_radio_cfg->countryCode != r_country_code) {
                         l_radio_cfg->countryCode = r_country_code;


### PR DESCRIPTION
…(#377) (#610)

Reason for change: As part of XER10 ROI, as using same partner as sky-uk, when we set default country code as IE (Ireland), onewifi failed to set it. This occurred when we change default RegionCode in partners_defaults.json as IE for XER10 under sky-uk partner.

The issue is due to failure in copying default country code as IE in wifi_db_apis.c.

Here corrected the string copy opertauon to properly get the country code from bootstrap.json.

Test Procedure:
1. Load the image
2. Make sure default country code came as IE instead of GB for XER10 UK.

Priority:P1